### PR TITLE
Format error messages better

### DIFF
--- a/validation.go
+++ b/validation.go
@@ -134,8 +134,15 @@ func (val *Validation) Validate(checkers ...Checker) *Validation {
 }
 
 func (val *Validation) constructErrorMessage() error {
+	if len(val.Errors) == 1 {
+		return fmt.Errorf(
+			"parameter validation failed: %s",
+			val.Errors[0],
+		)
+	}
+	
 	return fmt.Errorf(
-		"parameter validation failed:\t%s",
+		"parameter validation failed:\n\t%s",
 		strings.Join(val.Errors, "\n\t"),
 	)
 }


### PR DESCRIPTION
The error output was a tad sore on the eyes in some cases, so I've adjusted it like so:

* In the case of a single error, it outputs on the same line with no tab now.

Before:
```
parameter validation failed:     Parameter is an empty string: env
```

After:
```
parameter validation failed: Parameter is an empty string: env
```

* In the case of multiple errors, move the first error from the first line onto the second.

Before:

```
parameter validation failed:	Parameter is an empty string: db
	Parameter is an empty string: user
	Parameter is an empty string: host
```

After:

```
parameter validation failed:
	Parameter is an empty string: db
	Parameter is an empty string: user
	Parameter is an empty string: host
```

Thanks.